### PR TITLE
Adds an option to pass '--disable-dev-shm-usage' through to chrome

### DIFF
--- a/tests/BrowserTestCase.php
+++ b/tests/BrowserTestCase.php
@@ -67,6 +67,10 @@ abstract class BrowserTestCase extends DuskTestCase
                 '--disable-gpu',
                 '--headless',
             ]);
+        })->when($this->hasDevShmUsageDisabled(), function (Collection $items) {
+            return $items->merge([
+                '--disable-dev-shm-usage',
+            ]);
         })->all());
 
         return RemoteWebDriver::create(
@@ -84,6 +88,15 @@ abstract class BrowserTestCase extends DuskTestCase
     {
         return isset($_SERVER['DUSK_HEADLESS_DISABLED']) ||
                isset($_ENV['DUSK_HEADLESS_DISABLED']);
+    }
+
+    /**
+     * Determine if we should disable dev SHM usage in chromedriver
+     */
+    protected function hasDevShmUsageDisabled(): bool
+    {
+        return isset($_SERVER['DUSK_DEV_SHM_USAGE_DISABLED']) ||
+               isset($_ENV['DUSK_DEV_SHM_USAGE_DISABLED']);
     }
 
     /**


### PR DESCRIPTION
I run WSL2/Docker for my local dev env, and this option is required if I want to run more than one test in succession 🙃.  Figured others could benefit. 